### PR TITLE
Small change to CTL logo alt text

### DIFF
--- a/quizcon/templates/base.html
+++ b/quizcon/templates/base.html
@@ -152,7 +152,7 @@
             <div class= "row container-fluid">
                 <div class="col">
                 <a href="https://ctl.columbia.edu" target="_blank">
-                    <img id="footer-logo" src="{{STATIC_URL}}img/logo-black-ctl.svg" alt="Center for Teaching and Learning" />
+                    <img id="footer-logo" src="{{STATIC_URL}}img/logo-black-ctl.svg" alt="Center for Teaching and Learning at Columbia University" />
                 </a>
             </div>
             </div>


### PR DESCRIPTION
I looked at Logic Learner, and I just used what the alt text there is for CTL logo, just adding "Columbia" to it.