### PR TITLE
remove hardcoded creds

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,8 +26,8 @@
 Cypress.Commands.add('login', (username, password) => {
     cy.visit('/accounts/logout/?next=/');
     cy.get('#guest-login').click();
-    cy.get('#id_username').type('faculty_one').blur();
-    cy.get('#id_password').type('test').blur();
+    cy.get('#id_username').type(username).blur();
+    cy.get('#id_password').type(password).blur();
     cy.get('#guest-login-submit').click({force: true});
 });
 


### PR DESCRIPTION
The test use and password were hardcoded here. This removes them and uses function params instead.