### PR TITLE
see if this fixes cypress issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "cypress:head": "cypress run --headless --browser electron",
-    "cypress:test": "start-server-and-test 'make integrationserver' http-get://localhost:8000 cypress:run",
-    "cypress:test-headless": "start-server-and-test 'make integrationserver' http-get://localhost:8000 cypress:head"
+    "cypress:test": "start-server-and-test 'make integrationserver' http://127.0.0.1:8000 cypress:run",
+    "cypress:test-headless": "start-server-and-test 'make integrationserver' http://127.0.0.1:8000 cypress:head"
   },
   "devDependencies": {
     "axe-core": "^4.1.4",

--- a/quizcon/settings_shared.py
+++ b/quizcon/settings_shared.py
@@ -25,6 +25,8 @@ INSTALLED_APPS += [  # noqa
     'quizcon.main',
 ]
 
+ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
+
 MIDDLEWARE += [ # noqa
     'quizcon.main.middleware.WhoDidItMiddleware'
 ]

--- a/quizcon/settings_shared.py
+++ b/quizcon/settings_shared.py
@@ -25,7 +25,7 @@ INSTALLED_APPS += [  # noqa
     'quizcon.main',
 ]
 
-ALLOWED_HOSTS = ['127.0.0.1', 'localhost']
+ALLOWED_HOSTS += ['127.0.0.1']  # noqa
 
 MIDDLEWARE += [ # noqa
     'quizcon.main.middleware.WhoDidItMiddleware'


### PR DESCRIPTION
> Node 17+ changed how they resolve DNS names. Changing localhost to 127.0.0.1 is the fix for this issue

https://github.com/cypress-io/cypress/pull/21430